### PR TITLE
fix: number-to-string() and today()

### DIFF
--- a/builtins.go
+++ b/builtins.go
@@ -40,11 +40,9 @@ func extractList(args map[string]any, argName string) ([]any, error) {
 			}
 			return listV, nil
 		} else {
-			//return nil, NewEvalError(-7002, "cannot extract list")
 			return nil, NewErrTypeMismatch("list")
 		}
 	} else {
-		//return nil, NewEvalError(-7001, "no argument name")
 		return nil, NewErrKeyNotFound(argName)
 	}
 }

--- a/builtins_misc_test.go
+++ b/builtins_misc_test.go
@@ -1,0 +1,18 @@
+package feel
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func Test_builtin_misc_today_just_returns_a_date(t *testing.T) {
+	actual, err := EvalString(`today()`)
+	assert.Nil(t, err)
+
+	now := time.Now()
+	date := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	expected := FEELDate{t: date}
+
+	assert.Equal(t, &expected, actual)
+}

--- a/builtins_strings_test.go
+++ b/builtins_strings_test.go
@@ -46,6 +46,10 @@ func Test_builtin_string_functions(t *testing.T) {
 			expr:   `"foo" + "bar"`,
 			result: "foobar",
 		},
+		{
+			expr:   `string(123)`, // method implemented, but return type should be native Go type
+			result: "123",
+		},
 
 		//{
 		//	expr:   `string length("foobar")`,    // method implemented, but return type should be native Go type
@@ -70,10 +74,6 @@ func Test_builtin_string_functions(t *testing.T) {
 		//{
 		//	expr:   `split("foo,bar", ",")`, 	// method not yet implemented
 		//	result: []string{"foo", "bar"},
-		//},
-		//{
-		//	expr:   `string(123)`,             // method implemented, but return type should be native Go type
-		//	result: "123",
 		//},
 	}
 	for _, test := range tests {

--- a/numeric.go
+++ b/numeric.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"math/big"
+	"strings"
 )
 
 const (
@@ -135,8 +136,10 @@ func (n Number) Compare(other Number) int {
 }
 
 func (n Number) String() string {
-	//return n.v.String()
-	return n.v.Text('f', 18)
+	s := n.v.Text('f', 18)
+	s = strings.TrimRight(s, "0")
+	s = strings.TrimRight(s, ".")
+	return s
 }
 
 func (n Number) MarshalJSON() ([]byte, error) {

--- a/temporal.go
+++ b/temporal.go
@@ -437,7 +437,9 @@ func installDatetimeFunctions(prelude *Prelude) {
 	}))
 
 	prelude.Bind("today", wrapTyped(func() (interface{}, error) {
-		return &FEELDate{t: time.Now()}, nil
+		now := time.Now()
+		date := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+		return &FEELDate{t: date}, nil
 	}))
 
 	prelude.Bind("day of week", wrapTyped(func(v HasDate) (interface{}, error) {


### PR DESCRIPTION
* change: when converting a FeelNumber to string, the zeros and decimal period gets trimmed (example`string(42)` resulted before `42.00000000000000` now with the change result=`42`)
* change: when using today() just the date is returned, and the hour/minute/seconds are set to 0 (before it contains also all these parts) - this helps comparing, because when today() is called twice, it could be seconds in between and then the comparison would be no more equal. 