### PR TITLE
fix: implicit type conversion when math operations of different types

### DIFF
--- a/builtins.go
+++ b/builtins.go
@@ -560,7 +560,7 @@ func installBuiltinFunctions(prelude *Prelude) {
 			if s, ok := v.(string); ok {
 				strArray = append(strArray, s)
 			} else if _, ok := v.(*NullValue); !ok {
-				return Null, nil
+				return null, nil
 			}
 		}
 		joined := fmt.Sprintf("%s%s%s", args.Prefix, strings.Join(strArray, args.Delimiter), args.Suffix)

--- a/context.go
+++ b/context.go
@@ -94,13 +94,13 @@ func installContextFunctions(prelude *Prelude) {
 			if v, ok := contextGetByKeys(argsByKeys.Context, argsByKeys.Keys); ok {
 				return v, nil
 			} else {
-				return Null, nil
+				return null, nil
 			}
 		} else {
 			if v, ok := argsByKey.Context[argsByKey.Key]; ok {
 				return v, nil
 			} else {
-				return Null, nil
+				return null, nil
 			}
 		}
 	}).Required("context", "key"))

--- a/error_types.go
+++ b/error_types.go
@@ -35,9 +35,6 @@ func NewErrIndex(msg string) *EvalError {
 func NewErrTypeMismatch(expectType string) *EvalError {
 	return NewEvalError(-4002, "type mismatch", "expect", expectType)
 }
-func NewErrValue(msg string) *EvalError {
-	return NewEvalError(-4003, "value error", msg)
-}
 
 // NewErrKeywordArgument argument errors
 func NewErrKeywordArgument(argName string) *EvalError {

--- a/eval.go
+++ b/eval.go
@@ -6,6 +6,7 @@ import (
 )
 
 // values
+var null = &NullValue{}
 
 type NullValue struct {
 }
@@ -17,8 +18,6 @@ func (self NullValue) Equal(other NullValue) bool {
 func (self NullValue) MarshalJSON() ([]byte, error) {
 	return json.Marshal(nil)
 }
-
-var Null = &NullValue{}
 
 func boolValue(condVal any) bool {
 	switch v := condVal.(type) {
@@ -81,6 +80,9 @@ func typeName(a any) string {
 }
 
 func normalizeValue(v any) any {
+	if v == nil {
+		return null
+	}
 	switch vv := v.(type) {
 	case int:
 		return NewNumberFromInt64(int64(vv))
@@ -183,7 +185,7 @@ func (boolNode BoolNode) Eval(intp *Interpreter) (any, error) {
 }
 
 func (nullNode NullNode) Eval(intp *Interpreter) (any, error) {
-	return Null, nil
+	return null, nil
 }
 
 func (stringNode StringNode) Eval(intp *Interpreter) (any, error) {
@@ -199,7 +201,7 @@ func (v Var) Eval(intp *Interpreter) (any, error) {
 		return v, nil
 	} else {
 		//return nil, NewErrKeyNotFound(v.Name)
-		return Null, nil
+		return null, nil
 	}
 }
 
@@ -581,7 +583,7 @@ func (fc FunCall) EvalFunDef(intp *Interpreter, funDef *FunDef) (any, error) {
 				intp.Bind(argName, v)
 			} else {
 				//return nil, NewEvalError(-5001, "no keyword argument", fmt.Sprintf("no keyword argument %s", argName))
-				intp.Bind(argName, Null)
+				intp.Bind(argName, null)
 			}
 		}
 	} else {

--- a/eval_binop.go
+++ b/eval_binop.go
@@ -193,11 +193,17 @@ func (binop Binop) typedOp(intp *Interpreter, es evalStrings, en evalNumbers, op
 			if rightString, ok := rightVal.(string); ok {
 				return es(v, rightString), nil
 			}
+			if rightNumber, ok := rightVal.(*Number); ok {
+				return es(v, rightNumber.String()), nil
+			}
 		}
 	case *Number:
 		if en != nil {
 			if rightNumber, ok := rightVal.(*Number); ok {
 				return en(v, rightNumber), nil
+			}
+			if rightString, ok := rightVal.(string); ok {
+				return es(v.String(), rightString), nil
 			}
 		}
 	case *FEELDatetime:
@@ -213,7 +219,6 @@ func (binop Binop) typedOp(intp *Interpreter, es evalStrings, en evalNumbers, op
 			}
 		}
 	}
-	//return nil, NewEvalError(-3101, "invalid types", fmt.Sprintf("bad types in op, %s %s %s", typeName(leftVal), op, typeName(rightVal)))
 	return nil, NewErrBadOp(typeName(leftVal), op, typeName(rightVal))
 }
 

--- a/eval_binop.go
+++ b/eval_binop.go
@@ -80,9 +80,17 @@ func compareInterfaces(leftVal, rightVal any) (int, error) {
 		if rightString, ok := rightVal.(string); ok {
 			return strings.Compare(v, rightString), nil
 		}
+		if _, ok := rightVal.(*NullValue); ok {
+			// every value is bigger than NullValue
+			return 1, nil
+		}
 	case *Number:
 		if rightNumber, ok := rightVal.(*Number); ok {
 			return v.Compare(*rightNumber), nil
+		}
+		if _, ok := rightVal.(*NullValue); ok {
+			// every value is bigger than NullValue
+			return 1, nil
 		}
 	case *NullValue:
 		if _, ok := rightVal.(*NullValue); ok {
@@ -98,6 +106,10 @@ func compareInterfaces(leftVal, rightVal any) (int, error) {
 				return 1, nil
 			}
 		}
+		if _, ok := rightVal.(*NullValue); ok {
+			// every value is bigger than NullValue
+			return 1, nil
+		}
 	case HasTime:
 		if rightHasTime, ok := rightVal.(HasTime); ok {
 			if v.Time().Equal(rightHasTime.Time()) {
@@ -108,13 +120,25 @@ func compareInterfaces(leftVal, rightVal any) (int, error) {
 				return 1, nil
 			}
 		}
+		if _, ok := rightVal.(*NullValue); ok {
+			// every value is bigger than NullValue
+			return 1, nil
+		}
 	case []any:
 		if rightArr, ok := rightVal.([]any); ok {
 			return compareArrays(v, rightArr)
 		}
+		if _, ok := rightVal.(*NullValue); ok {
+			// every value is bigger than NullValue
+			return 1, nil
+		}
 	case map[string]any:
 		if rightMap, ok := rightVal.(map[string]any); ok {
 			return compareMaps(v, rightMap)
+		}
+		if _, ok := rightVal.(*NullValue); ok {
+			// every value is bigger than NullValue
+			return 1, nil
 		}
 	}
 	return 0, NewEvalError(-3106, "invalid types", fmt.Sprintf("bad type in comparation, %T vs. %T", leftVal, rightVal))

--- a/eval_binop.go
+++ b/eval_binop.go
@@ -75,26 +75,26 @@ func CompareValues(leftVal, rightVal any) int {
 }
 
 func compareInterfaces(leftVal, rightVal any) (int, error) {
+	if _, ok := leftVal.(*NullValue); ok {
+		if _, ok = rightVal.(*NullValue); ok {
+			return 0, nil
+		}
+		// every (right) value is bigger than NullValue
+		return 1, nil
+	}
+	if _, ok := rightVal.(*NullValue); ok {
+		// every (left) value is bigger than NullValue
+		return -1, nil
+	}
+
 	switch v := leftVal.(type) {
 	case string:
 		if rightString, ok := rightVal.(string); ok {
 			return strings.Compare(v, rightString), nil
 		}
-		if _, ok := rightVal.(*NullValue); ok {
-			// every value is bigger than NullValue
-			return 1, nil
-		}
 	case *Number:
 		if rightNumber, ok := rightVal.(*Number); ok {
 			return v.Compare(*rightNumber), nil
-		}
-		if _, ok := rightVal.(*NullValue); ok {
-			// every value is bigger than NullValue
-			return 1, nil
-		}
-	case *NullValue:
-		if _, ok := rightVal.(*NullValue); ok {
-			return 0, nil
 		}
 	case bool:
 		if rightBool, ok := rightVal.(bool); ok {
@@ -106,10 +106,6 @@ func compareInterfaces(leftVal, rightVal any) (int, error) {
 				return 1, nil
 			}
 		}
-		if _, ok := rightVal.(*NullValue); ok {
-			// every value is bigger than NullValue
-			return 1, nil
-		}
 	case HasTime:
 		if rightHasTime, ok := rightVal.(HasTime); ok {
 			if v.Time().Equal(rightHasTime.Time()) {
@@ -120,25 +116,13 @@ func compareInterfaces(leftVal, rightVal any) (int, error) {
 				return 1, nil
 			}
 		}
-		if _, ok := rightVal.(*NullValue); ok {
-			// every value is bigger than NullValue
-			return 1, nil
-		}
 	case []any:
 		if rightArr, ok := rightVal.([]any); ok {
 			return compareArrays(v, rightArr)
 		}
-		if _, ok := rightVal.(*NullValue); ok {
-			// every value is bigger than NullValue
-			return 1, nil
-		}
 	case map[string]any:
 		if rightMap, ok := rightVal.(map[string]any); ok {
 			return compareMaps(v, rightMap)
-		}
-		if _, ok := rightVal.(*NullValue); ok {
-			// every value is bigger than NullValue
-			return 1, nil
 		}
 	}
 	return 0, NewEvalError(-3106, "invalid types", fmt.Sprintf("bad type in comparation, %T vs. %T", leftVal, rightVal))

--- a/eval_binop_test.go
+++ b/eval_binop_test.go
@@ -55,14 +55,90 @@ func Test_implicit_type_conversation_in_math_operation(t *testing.T) {
 			expr:   `b + a`,
 			result: "bar2",
 		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.expr, func(t *testing.T) {
+			scope := map[string]any{
+				"a": test.a,
+				"b": test.b,
+			}
+			actual, err := EvalStringWithScope(test.expr, scope)
+			assert.Nil(t, err)
+			assert.Equal(t, test.result, actual)
+		})
+	}
+}
+
+func Test_compare_with_null_values_is_always_true(t *testing.T) {
+	tests := []struct {
+		a      any
+		expr   string
+		result any
+	}{
 		{
-			a:      37,
+			a:      "aString",
 			expr:   `a != null`,
 			result: true,
 		},
 		{
-			b:      "foobar",
-			expr:   `b != null`,
+			a:      42,
+			expr:   `a != null`,
+			result: true,
+		},
+		{
+			a:      true,
+			expr:   `a != null`,
+			result: true,
+		},
+		{
+			a:      false,
+			expr:   `a != null`,
+			result: true,
+		},
+		//{
+		//	a:      time.Now(), // FIXME: this is not detected in compareInterfaces()
+		//	expr:   `a != null`,
+		//	result: true,
+		//},
+		//{
+		//	a:      []string{"x", "y"}, // FIXME: this is not detected in compareInterfaces()
+		//	expr:   `a != null`,
+		//	result: true,
+		//},
+		//{
+		//	a:      map[string]any{"x": 1, "y": true}, // FIXME: this is not detected in compareInterfaces()
+		//	expr:   `a != null`,
+		//	result: true,
+		//},
+	}
+
+	for _, test := range tests {
+		t.Run(test.expr, func(t *testing.T) {
+			scope := map[string]any{
+				"a": test.a,
+			}
+			actual, err := EvalStringWithScope(test.expr, scope)
+			assert.Nil(t, err)
+			assert.Equal(t, test.result, actual)
+		})
+	}
+}
+
+func Test_eval_multiple_operators_with_logical_precedence(t *testing.T) {
+	// FIXME: implement operator precedence
+	t.Skip("implement operator precedence")
+	tests := []struct {
+		a      any
+		b      any
+		expr   string
+		result any
+	}{
+		{
+			a: true,
+			b: 1,
+			// hint: no-equal must be before and
+			expr:   `a and b != null`,
 			result: true,
 		},
 	}

--- a/eval_binop_test.go
+++ b/eval_binop_test.go
@@ -77,8 +77,23 @@ func Test_compare_with_null_values_is_always_true(t *testing.T) {
 		result any
 	}{
 		{
+			a:      nil,
+			expr:   `a != null`,
+			result: false,
+		},
+		{
+			a:      nil,
+			expr:   `a = null`,
+			result: true,
+		},
+		{
 			a:      "aString",
 			expr:   `a != null`,
+			result: true,
+		},
+		{
+			a:      "aString",
+			expr:   `null != a`,
 			result: true,
 		},
 		{

--- a/eval_binop_test.go
+++ b/eval_binop_test.go
@@ -131,6 +131,8 @@ func Test_eval_multiple_operators_with_logical_precedence(t *testing.T) {
 	tests := []struct {
 		a      any
 		b      any
+		x      any
+		y      any
 		expr   string
 		result any
 	}{
@@ -141,6 +143,14 @@ func Test_eval_multiple_operators_with_logical_precedence(t *testing.T) {
 			expr:   `a and b != null`,
 			result: true,
 		},
+		{
+			a:      true,
+			b:      false,
+			x:      true,
+			y:      true,
+			expr:   `a and b or x and y`,
+			result: true,
+		},
 	}
 
 	for _, test := range tests {
@@ -148,6 +158,8 @@ func Test_eval_multiple_operators_with_logical_precedence(t *testing.T) {
 			scope := map[string]any{
 				"a": test.a,
 				"b": test.b,
+				"x": test.x,
+				"y": test.y,
 			}
 			actual, err := EvalStringWithScope(test.expr, scope)
 			assert.Nil(t, err)

--- a/eval_binop_test.go
+++ b/eval_binop_test.go
@@ -35,3 +35,47 @@ func Test_compareInterfaces(t *testing.T) {
 		})
 	}
 }
+
+func Test_implicit_type_conversation_in_math_operation(t *testing.T) {
+	tests := []struct {
+		a      any
+		b      any
+		expr   string
+		result any
+	}{
+		{
+			a:      1,
+			b:      "foo",
+			expr:   `a + b`,
+			result: "1foo",
+		},
+		{
+			a:      2,
+			b:      "bar",
+			expr:   `b + a`,
+			result: "bar2",
+		},
+		{
+			a:      37,
+			expr:   `a != null`,
+			result: true,
+		},
+		{
+			b:      "foobar",
+			expr:   `b != null`,
+			result: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.expr, func(t *testing.T) {
+			scope := map[string]any{
+				"a": test.a,
+				"b": test.b,
+			}
+			actual, err := EvalStringWithScope(test.expr, scope)
+			assert.Nil(t, err)
+			assert.Equal(t, test.result, actual)
+		})
+	}
+}

--- a/eval_binop_test.go
+++ b/eval_binop_test.go
@@ -36,7 +36,7 @@ func Test_compareInterfaces(t *testing.T) {
 	}
 }
 
-func Test_implicit_type_conversation_in_math_operation(t *testing.T) {
+func Test_implicit_type_conversion_in_math_operation(t *testing.T) {
 	tests := []struct {
 		a      any
 		b      any

--- a/eval_test.go
+++ b/eval_test.go
@@ -116,11 +116,11 @@ func Test_EvalString(t *testing.T) {
 		{`and([true, 1, true, "ok"])`, true},
 
 		// context/map functions
-		{`get value({a: 2}, "b")`, Null},
+		{`get value({a: 2}, "b")`, null},
 		{`get value({a: 2}, "a")`, N(2)},
 		{`get value({a: {b: {c: 4}}}, ["a", "b", "c"])`, N(4)},
 		{`get value({a: {b: {c: 4}}}, ["a", "b"])`, map[string]any{"c": N(4)}},
-		{`get value({a: {b: {c: 4}}}, ["a", "k"])`, Null},
+		{`get value({a: {b: {c: 4}}}, ["a", "k"])`, null},
 		{`get value(context put({a: false}, ["b", "c", "d"], 4), ["b", "c"])`, map[string]any{"d": N(4)}},
 		{`context merge([{x:1, y: 0}, {y:2}])`, map[string]any{"x": N(1), "y": N(2)}},
 

--- a/temporal_test.go
+++ b/temporal_test.go
@@ -1,0 +1,38 @@
+package feel
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func Test_time_is_supported_in_evaluation_scope(t *testing.T) {
+	t.Skip("Go's time, and date, and duration values should be supported in scope")
+	tests := []struct {
+		a      any
+		expr   string
+		result any
+	}{
+		{
+			a:      time.Date(2025, 04, 13, 17, 27, 58, 123456, time.UTC),
+			expr:   `a != null`,
+			result: true,
+		},
+		{
+			a:      FEELTime{t: time.Date(2025, 04, 13, 17, 27, 58, 123456, time.UTC)},
+			expr:   `a != null`,
+			result: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.expr, func(t *testing.T) {
+			scope := map[string]any{
+				"a": test.a,
+			}
+			actual, err := EvalStringWithScope(test.expr, scope)
+			assert.Nil(t, err)
+			assert.Equal(t, test.result, actual)
+		})
+	}
+}


### PR DESCRIPTION
This PR only fixes some part of issue #8 
Since many root causes are requested by this issue 8, this PR is meant to fix some but not all - since this would be way more work. Next to the actual fixes, this PR contains hints and disabled tests for other issues #11 and #12 (future work) 

- Fix: data: `{"a":1, "b":"foo"}` expression: `a + b`-  now string conversion happens and thus the expected outcome is `1foo` 
- Fix: [expression:`b != null` - now results in `true` 
- Still open: data: `{"a":true, "b": 1}` expression:` a and b != null` - see #11 