### PR TITLE
Fix endless loop issue

### DIFF
--- a/error_types.go
+++ b/error_types.go
@@ -53,3 +53,7 @@ func NewErrTooManyArguments() *EvalError {
 func NewErrBadOp(leftType, op, rightType string) *EvalError {
 	return NewEvalError(-5001, "type mismatch in op", "bad types in op, ", leftType, op, rightType)
 }
+
+func NewErrBadInput(row int, column int, inputText string) *EvalError {
+	return NewEvalError(-6001, "bad input", fmt.Sprintf(`at position row:%d, column:%d, input:%s`, row, column, inputText))
+}

--- a/eval_test.go
+++ b/eval_test.go
@@ -18,6 +18,15 @@ func Test_N(t *testing.T) {
 	assert.Empty(t, cmp.Diff(N(11), res))
 }
 
+func Test_unknown_symbols_raise_error(t *testing.T) {
+	scope := map[string]any{
+		"COUNT": 15,
+	}
+	input := `COUNT <= 20 && COUNT > 10`
+	_, err := EvalStringWithScope(input, scope)
+	assert.ErrorContains(t, err, "bad input")
+}
+
 func Test_EvalString(t *testing.T) {
 	tests := []struct {
 		input  string

--- a/scan.go
+++ b/scan.go
@@ -2,7 +2,6 @@ package feel
 
 import (
 	"errors"
-	"fmt"
 	"regexp"
 	"strings"
 )
@@ -224,6 +223,6 @@ func (scanner *Scanner) Next() error {
 		scanner.currentToken = ScannerToken{Kind: TokenEOF, Pos: scanner.Pos}
 		return nil
 	} else {
-		return errors.New(fmt.Sprintf("at position %d %d, bad input %s", scanner.Pos.Row, scanner.Pos.Column, scanner.rest))
+		return NewErrBadInput(scanner.Pos.Row, scanner.Pos.Column, scanner.rest)
 	}
 }

--- a/temporal.go
+++ b/temporal.go
@@ -269,9 +269,9 @@ func (duration FEELDuration) MarshalJSON() ([]byte, error) {
 
 func (duration FEELDuration) Duration() time.Duration {
 	// duration.Year and duration.Month
-	dv := (time.Duration(duration.Days*24+duration.Hours)*time.Hour +
+	dv := time.Duration(duration.Days*24+duration.Hours)*time.Hour +
 		time.Duration(duration.Minutes)*time.Minute +
-		time.Duration(duration.Seconds)*time.Second)
+		time.Duration(duration.Seconds)*time.Second
 	if duration.Neg {
 		dv = -dv
 	}

--- a/temporal.go
+++ b/temporal.go
@@ -278,8 +278,8 @@ func (duration FEELDuration) Duration() time.Duration {
 	return dv
 }
 
-func (duration *FEELDuration) Negative() *FEELDuration {
-	neg := *duration
+func (duration FEELDuration) Negative() *FEELDuration {
+	neg := duration
 	neg.Neg = !duration.Neg
 	return &neg
 }


### PR DESCRIPTION
Hint: without the checks for error, the parser remains within an endless loop.
Thus, the fix is to check for error on each .Next() operation.

fix #14